### PR TITLE
Update ignore.lua

### DIFF
--- a/client/ignore.lua
+++ b/client/ignore.lua
@@ -57,3 +57,35 @@ Citizen.CreateThread(function()
     end
 end)
 
+--Fixes the issue where you can't move or interact with anything after pressing space for the abilities
+CreateThread(function()
+    --Citizen.InvokeNative(0xAD7B70F7230C5A12) --this native clears all apps
+    while true do        
+        if IsControlJustPressed(0, 0xAC4BD4F1) or IsDisabledControlJustPressed(0, 0xAC4BD4F1) then
+            exitMenu = false
+            while not exitMenu do 
+                if not IsControlPressed(0, 0xAC4BD4F1) and not IsDisabledControlJustPressed(0, 0xAC4BD4F1) then
+                    Citizen.InvokeNative(0xAD7B70F7230C5A12)
+                    exitMenu = true
+                end
+                Wait(1)
+            end
+        end
+        
+        if IsControlPressed(0,0x1F6D95E5) or IsDisabledControlJustPressed(0,0x1F6D95E5) then
+            if IsControlPressed(0, 0x77E56FB3 ) or IsDisabledControlJustPressed(0, 0x77E56FB3 ) then
+                exitMenu = false
+                while not exitMenu do 
+                    if not IsControlPressed(0, 0x1F6D95E5) and not IsDisabledControlJustPressed(0, 0x1F6D95E5) then
+                        
+                        Citizen.InvokeNative(0xAD7B70F7230C5A12)
+                        exitMenu = true
+                    end
+                    Wait(1)
+                end
+            end
+        end
+        Wait(1)
+    end
+ end)
+


### PR DESCRIPTION
Issue: Can't move or interact with anything after pressing space for the abilities (Hard Lock)

Fix: tracks button presses to check if player enters in the animation uiapp. If in the menu releasing that menu button will trigger a close uiapp 

Expected result: Pressing f4 ->R ->Space or TAB -> Space no longer hard locks player