### PR TITLE
Update ignore.lua

### DIFF
--- a/client/ignore.lua
+++ b/client/ignore.lua
@@ -1,14 +1,18 @@
 -- removes events or create Event Triggers to Utilize instead needing to loop in each resource
 local GameEvents = {
-    [`EVENT_LOOT_COMPLETE`] = 'Looted', ---- Example This will trigger event QBCore:Event:Looted and include data for ped and the entity interacting with
+    [`EVENT_LOOT_COMPLETE`] = {name = 'Looted', size = 3},
+    [`EVENT_INVENTORY_ITEM_PICKED_UP`] = {name = 'PickupItem', size = 5},
+    [`EVENT_PED_WHISTLE`] = {name = 'Whistle', size = 2},
+    [`EVENT_PLAYER_PROMPT_TRIGGERED`] = {name = 'PedPrompt', size = 10},
 }
 
 local function DataViewEvent(eventGroup, index, argStructSize)
-    local buffer = string.rep("\0", 16)
+    local buffer = string.rep("\0", argStructSize * 8)
     Citizen.InvokeNative(0x57EC5FA4D4D6AFCA, eventGroup, index, buffer, argStructSize)
     local data = {}
     data.ped = string.unpack("i4", buffer, 0)
-    data.target = string.unpack("i4", buffer, 9)
+    data.target = argStructSize > 1 and string.unpack("i4", buffer, 9)
+    data.complete = argStructSize > 2 and string.unpack("i4", buffer, 17)
     return data
 end
 
@@ -24,8 +28,8 @@ CreateThread(function()
                     Citizen.InvokeNative(0x6035E8FBCA32AC5E)
                 elseif GameEvents[eventAtIndex] then
                     local current = GameEvents[eventAtIndex]
-                    local data = DataViewEvent(0, i, 3)
-                    TriggerEvent('QBCore:Event:'..current, data)
+                    local data = DataViewEvent(0, i, current.size)
+                    TriggerEvent('QBCore:Event:'..current.name, data)
                 end
             end
         end


### PR DESCRIPTION
Additional Game Event Triggers added for Example Whistle this will help up to remove the need to loop for calling Horse. Also Player Prompt to be able to utilize things like the Emote Menu Prompt to Actually open the Emote menu. the data.complete is now sent if struct size is greater than 2 As a Precaution to make sure the loot is 100% completed when skinning a animal.